### PR TITLE
Add tea session frontend flows

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { Navigate, NavLink, Route, Routes } from "react-router";
 import { NewTeaPage } from "./pages/NewTeaPage";
+import { SessionDetailPage } from "./pages/SessionDetailPage";
+import { SessionsPage } from "./pages/SessionsPage";
 import { TeaDetailPage } from "./pages/TeaDetailPage";
 import { TeasPage } from "./pages/TeasPage";
 
@@ -37,24 +39,6 @@ function NavItem({ to, children }: { to: string; children: ReactNode }) {
   );
 }
 
-function SessionsPage() {
-  return (
-    <section className="panel stack">
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">Sessions</p>
-          <h2>Tasting sessions</h2>
-        </div>
-        <p className="muted">A place for brewing notes and tasting history.</p>
-      </div>
-
-      <p className="muted">
-        Session tracking is coming next. For now, you can browse and manage your tea collection.
-      </p>
-    </section>
-  );
-}
-
 export default function App() {
   return (
     <ShellLayout>
@@ -64,6 +48,7 @@ export default function App() {
         <Route path="/teas/new" element={<NewTeaPage />} />
         <Route path="/teas/:teaId" element={<TeaDetailPage />} />
         <Route path="/sessions" element={<SessionsPage />} />
+        <Route path="/sessions/:sessionId" element={<SessionDetailPage />} />
       </Routes>
     </ShellLayout>
   );

--- a/frontend/src/features/sessions/SessionForm.tsx
+++ b/frontend/src/features/sessions/SessionForm.tsx
@@ -1,0 +1,118 @@
+import type { FormEvent, ReactNode } from "react";
+import type { Tea } from "../teas/api";
+import type { TeaSessionFormState } from "./formState";
+
+type SessionFormProps = {
+  form: TeaSessionFormState;
+  teas: Tea[];
+  onChange: (nextForm: TeaSessionFormState) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  submitLabel: string;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+  secondaryAction?: ReactNode;
+};
+
+export function SessionForm({
+  form,
+  teas,
+  onChange,
+  onSubmit,
+  submitLabel,
+  isSubmitting = false,
+  errorMessage,
+  secondaryAction,
+}: SessionFormProps) {
+  function updateField<K extends keyof TeaSessionFormState>(
+    field: K,
+    value: TeaSessionFormState[K],
+  ) {
+    onChange({ ...form, [field]: value });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="stack">
+      <div className="field-grid">
+        <label className="field">
+          <span className="field__label">Tea</span>
+          <select
+            className="field__input"
+            value={form.tea_id}
+            onChange={(event) => updateField("tea_id", event.target.value)}
+            required
+          >
+            <option value="">Select a tea</option>
+            {teas.map((tea) => (
+              <option key={tea.id} value={tea.id}>
+                {tea.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="field">
+          <span className="field__label">Session date</span>
+          <input
+            className="field__input"
+            type="datetime-local"
+            value={form.session_date}
+            onChange={(event) => updateField("session_date", event.target.value)}
+            required
+          />
+        </label>
+      </div>
+
+      <div className="field-grid">
+        <label className="field">
+          <span className="field__label">Steeps</span>
+          <input
+            className="field__input"
+            type="number"
+            min="0"
+            inputMode="numeric"
+            placeholder="3"
+            value={form.steeps_count}
+            onChange={(event) => updateField("steeps_count", event.target.value)}
+          />
+        </label>
+
+        <label className="field">
+          <span className="field__label">Rating</span>
+          <input
+            className="field__input"
+            type="number"
+            min="0"
+            max="100"
+            inputMode="numeric"
+            placeholder="85"
+            value={form.rating}
+            onChange={(event) => updateField("rating", event.target.value)}
+          />
+        </label>
+      </div>
+
+      <label className="field">
+        <span className="field__label">Notes</span>
+        <textarea
+          className="field__input field__input--textarea"
+          placeholder="Brewing notes, aromas, or quick impressions"
+          value={form.notes}
+          onChange={(event) => updateField("notes", event.target.value)}
+        />
+      </label>
+
+      {errorMessage ? <p className="feedback feedback--error">{errorMessage}</p> : null}
+
+      <div className="button-row">
+        <button
+          type="submit"
+          disabled={isSubmitting || teas.length === 0}
+          className="button button--primary"
+        >
+          {isSubmitting ? "Saving..." : submitLabel}
+        </button>
+        {secondaryAction}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/sessions/api.ts
+++ b/frontend/src/features/sessions/api.ts
@@ -1,0 +1,46 @@
+import { apiFetch } from "../../lib/api";
+
+export type TeaSession = {
+  id: number;
+  tea_id: number;
+  session_date: string;
+  steeps_count: number | null;
+  rating: number | null;
+  notes: string | null;
+};
+
+export type TeaSessionInput = {
+  tea_id: number;
+  session_date: string;
+  steeps_count?: number | null;
+  rating?: number | null;
+  notes?: string | null;
+};
+
+export function listSessions() {
+  return apiFetch<TeaSession[]>("/sessions");
+}
+
+export function getSession(sessionId: number) {
+  return apiFetch<TeaSession>(`/sessions/${sessionId}`);
+}
+
+export function createSession(input: TeaSessionInput) {
+  return apiFetch<TeaSession>("/sessions", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export function updateSession(sessionId: number, input: TeaSessionInput) {
+  return apiFetch<TeaSession>(`/sessions/${sessionId}`, {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+}
+
+export function deleteSession(sessionId: number) {
+  return apiFetch<void>(`/sessions/${sessionId}`, {
+    method: "DELETE",
+  });
+}

--- a/frontend/src/features/sessions/formState.ts
+++ b/frontend/src/features/sessions/formState.ts
@@ -1,0 +1,54 @@
+import type { TeaSession, TeaSessionInput } from "./api";
+
+export type TeaSessionFormState = {
+  tea_id: string;
+  session_date: string;
+  steeps_count: string;
+  rating: string;
+  notes: string;
+};
+
+export const initialTeaSessionFormState: TeaSessionFormState = {
+  tea_id: "",
+  session_date: "",
+  steeps_count: "",
+  rating: "",
+  notes: "",
+};
+
+function toDateTimeLocalInput(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const timezoneOffsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - timezoneOffsetMs).toISOString().slice(0, 16);
+}
+
+export function toTeaSessionFormState(session?: TeaSession): TeaSessionFormState {
+  if (!session) {
+    return initialTeaSessionFormState;
+  }
+
+  return {
+    tea_id: session.tea_id.toString(),
+    session_date: toDateTimeLocalInput(session.session_date),
+    steeps_count: session.steeps_count?.toString() ?? "",
+    rating: session.rating?.toString() ?? "",
+    notes: session.notes ?? "",
+  };
+}
+
+export function toTeaSessionPayload(
+  form: TeaSessionFormState,
+): TeaSessionInput {
+  return {
+    tea_id: Number(form.tea_id),
+    session_date: new Date(form.session_date).toISOString(),
+    steeps_count: form.steeps_count ? Number(form.steeps_count) : null,
+    rating: form.rating ? Number(form.rating) : null,
+    notes: form.notes.trim() || null,
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -346,6 +346,48 @@ select:disabled {
   font-size: 0.9rem;
 }
 
+
+.panel--nested {
+  border-radius: 20px;
+  background: rgba(248, 241, 232, 0.8);
+  box-shadow: none;
+}
+
+.tea-card__meta--two-up {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.inline-link {
+  color: #6b4f3d;
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
+}
+
+.pill--link {
+  border: 1px solid #d8c8b7;
+}
+
+.linked-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.linked-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid #ddd0c0;
+  border-radius: 16px;
+  background: #fffaf4;
+  padding: 0.9rem 1rem;
+}
+
+.linked-list__item span {
+  color: #6e5d52;
+}
+
 @media (max-width: 720px) {
   .site-header__inner,
   .page {
@@ -359,8 +401,14 @@ select:disabled {
   }
 
   .field-grid,
-  .tea-card__meta {
+  .tea-card__meta,
+  .tea-card__meta--two-up {
     grid-template-columns: 1fr;
+  }
+
+  .linked-list__item {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .button-row > * {

--- a/frontend/src/pages/SessionDetailPage.tsx
+++ b/frontend/src/pages/SessionDetailPage.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate, useParams } from "react-router";
+import { listTeas } from "../features/teas/api";
+import {
+  deleteSession,
+  getSession,
+  updateSession,
+} from "../features/sessions/api";
+import { SessionForm } from "../features/sessions/SessionForm";
+import {
+  type TeaSessionFormState,
+  toTeaSessionFormState,
+  toTeaSessionPayload,
+} from "../features/sessions/formState";
+
+export function SessionDetailPage() {
+  const params = useParams();
+  const sessionId = Number(params.sessionId);
+
+  const sessionQuery = useQuery({
+    queryKey: ["sessions", sessionId],
+    queryFn: () => getSession(sessionId),
+    enabled: Number.isInteger(sessionId) && sessionId > 0,
+  });
+
+  const teasQuery = useQuery({
+    queryKey: ["teas"],
+    queryFn: listTeas,
+    enabled: Number.isInteger(sessionId) && sessionId > 0,
+  });
+
+  if (!Number.isInteger(sessionId) || sessionId <= 0) {
+    return (
+      <section className="panel">
+        <p className="feedback feedback--error">Invalid session id.</p>
+      </section>
+    );
+  }
+
+  if (sessionQuery.isPending || teasQuery.isPending) {
+    return (
+      <section className="panel">
+        <p className="muted">Loading session...</p>
+      </section>
+    );
+  }
+
+  if (sessionQuery.isError || teasQuery.isError) {
+    return (
+      <section className="panel stack">
+        <p className="feedback feedback--error">
+          {sessionQuery.isError
+            ? (sessionQuery.error as Error).message
+            : (teasQuery.error as Error).message}
+        </p>
+        <Link to="/sessions" className="button button--secondary">
+          Back to sessions
+        </Link>
+      </section>
+    );
+  }
+
+  if (!sessionQuery.data) {
+    return (
+      <section className="panel">
+        <p className="feedback feedback--error">Tea session not found.</p>
+      </section>
+    );
+  }
+
+  return (
+    <SessionEditor
+      key={sessionQuery.data.id}
+      sessionId={sessionId}
+      initialForm={toTeaSessionFormState(sessionQuery.data)}
+      teas={teasQuery.data ?? []}
+      teaId={sessionQuery.data.tea_id}
+      sessionDate={sessionQuery.data.session_date}
+    />
+  );
+}
+
+type SessionEditorProps = {
+  sessionId: number;
+  initialForm: TeaSessionFormState;
+  teaId: number;
+  sessionDate: string;
+  teas: Awaited<ReturnType<typeof listTeas>>;
+};
+
+function SessionEditor({ sessionId, initialForm, teaId, sessionDate, teas }: SessionEditorProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<TeaSessionFormState>(initialForm);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  const selectedTeaName = useMemo(
+    () => teas.find((tea) => tea.id === Number(form.tea_id))?.name,
+    [form.tea_id, teas],
+  );
+
+  const updateMutation = useMutation({
+    mutationFn: () => updateSession(sessionId, toTeaSessionPayload(form)),
+    onSuccess: async (updatedSession) => {
+      setSaveMessage(`Session #${updatedSession.id} updated.`);
+      setForm(toTeaSessionFormState(updatedSession));
+      await queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      await queryClient.invalidateQueries({ queryKey: ["sessions", sessionId] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteSession(sessionId),
+    onSuccess: async () => {
+      queryClient.removeQueries({ queryKey: ["sessions", sessionId], exact: true });
+      navigate("/sessions", { replace: true });
+      await queryClient.invalidateQueries({ queryKey: ["sessions"], exact: true });
+    },
+  });
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaveMessage(null);
+    updateMutation.mutate();
+  }
+
+  function handleDelete() {
+    setSaveMessage(null);
+    deleteMutation.mutate();
+  }
+
+  return (
+    <section className="panel panel--form stack">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">Edit</p>
+          <h2>{selectedTeaName ?? `Session #${sessionId}`}</h2>
+        </div>
+        <p className="muted">Review the stored session, update it, or remove it.</p>
+      </div>
+
+      <div className="metadata-row">
+        <span className="pill">Session #{sessionId}</span>
+        <Link to={`/teas/${teaId}`} className="pill pill--link">
+          Tea #{teaId}
+        </Link>
+        <span className="pill">{new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(sessionDate))}</span>
+      </div>
+
+      {saveMessage ? <p className="feedback feedback--success">{saveMessage}</p> : null}
+
+      <SessionForm
+        form={form}
+        teas={teas}
+        onChange={setForm}
+        onSubmit={handleSubmit}
+        submitLabel="Save changes"
+        isSubmitting={updateMutation.isPending}
+        errorMessage={updateMutation.isError ? (updateMutation.error as Error).message : null}
+        secondaryAction={
+          <>
+            <Link to="/sessions" className="button button--secondary">
+              Back
+            </Link>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+              className="button button--danger"
+            >
+              {deleteMutation.isPending ? "Deleting..." : "Delete session"}
+            </button>
+          </>
+        }
+      />
+
+      {deleteMutation.isError ? (
+        <p className="feedback feedback--error">
+          {(deleteMutation.error as Error).message}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { listTeas } from "../features/teas/api";
+import {
+  createSession,
+  listSessions,
+  type TeaSession,
+} from "../features/sessions/api";
+import { SessionForm } from "../features/sessions/SessionForm";
+import {
+  initialTeaSessionFormState,
+  type TeaSessionFormState,
+  toTeaSessionPayload,
+} from "../features/sessions/formState";
+
+function formatSessionDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+export function SessionsPage() {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<TeaSessionFormState>(initialTeaSessionFormState);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  const teasQuery = useQuery({
+    queryKey: ["teas"],
+    queryFn: listTeas,
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ["sessions"],
+    queryFn: listSessions,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createSession,
+    onSuccess: async (createdSession) => {
+      setForm(initialTeaSessionFormState);
+      setSaveMessage(`Session #${createdSession.id} created.`);
+      await queryClient.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+
+  const teaNameById = useMemo(() => {
+    const teas = teasQuery.data ?? [];
+    return new Map(teas.map((tea) => [tea.id, tea.name]));
+  }, [teasQuery.data]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaveMessage(null);
+    createMutation.mutate(toTeaSessionPayload(form));
+  }
+
+  const isLoading = teasQuery.isPending || sessionsQuery.isPending;
+  const isError = teasQuery.isError || sessionsQuery.isError;
+  const errorMessage = teasQuery.isError
+    ? (teasQuery.error as Error).message
+    : sessionsQuery.isError
+      ? (sessionsQuery.error as Error).message
+      : null;
+
+  return (
+    <section className="stack">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">Sessions</p>
+          <h2>Tasting sessions</h2>
+        </div>
+        <div className="button-row">
+          <button
+            type="button"
+            onClick={() => {
+              void teasQuery.refetch();
+              void sessionsQuery.refetch();
+            }}
+            disabled={teasQuery.isFetching || sessionsQuery.isFetching}
+            className="button button--secondary"
+          >
+            {teasQuery.isFetching || sessionsQuery.isFetching ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+      </div>
+
+      <section className="panel panel--form stack">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Create</p>
+            <h3>Log a session</h3>
+          </div>
+          <p className="muted">Use a real tea record and save brewing notes directly to the backend.</p>
+        </div>
+
+        {teasQuery.isSuccess && teasQuery.data.length === 0 ? (
+          <div className="stack">
+            <p className="muted">Create a tea before logging sessions.</p>
+            <div>
+              <Link to="/teas/new" className="button button--primary">
+                Add tea first
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <>
+            {saveMessage ? <p className="feedback feedback--success">{saveMessage}</p> : null}
+            <SessionForm
+              form={form}
+              teas={teasQuery.data ?? []}
+              onChange={setForm}
+              onSubmit={handleSubmit}
+              submitLabel="Create session"
+              isSubmitting={createMutation.isPending}
+              errorMessage={createMutation.isError ? (createMutation.error as Error).message : null}
+              secondaryAction={
+                <button
+                  type="button"
+                  className="button button--secondary"
+                  onClick={() => {
+                    setSaveMessage(null);
+                    setForm(initialTeaSessionFormState);
+                  }}
+                >
+                  Clear
+                </button>
+              }
+            />
+          </>
+        )}
+      </section>
+
+      {isLoading ? <p className="panel muted">Loading sessions...</p> : null}
+      {isError && errorMessage ? <p className="panel feedback feedback--error">{errorMessage}</p> : null}
+
+      {!isLoading && !isError && sessionsQuery.data?.length === 0 ? (
+        <div className="panel stack">
+          <p className="muted">No sessions yet. Log one to verify the new session endpoints.</p>
+        </div>
+      ) : null}
+
+      {!isLoading && !isError && sessionsQuery.data && sessionsQuery.data.length > 0 ? (
+        <div className="tea-grid">
+          {sessionsQuery.data.map((session) => (
+            <SessionCard
+              key={session.id}
+              session={session}
+              teaName={teaNameById.get(session.tea_id) ?? `Tea #${session.tea_id}`}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function SessionCard({
+  session,
+  teaName,
+}: {
+  session: TeaSession;
+  teaName: string;
+}) {
+  return (
+    <article className="tea-card">
+      <div className="stack stack--tight">
+        <div className="tea-card__header">
+          <div>
+            <h3>{teaName}</h3>
+            <p className="muted">{formatSessionDate(session.session_date)}</p>
+          </div>
+          <span className="pill">Session #{session.id}</span>
+        </div>
+
+        <dl className="tea-card__meta tea-card__meta--two-up">
+          <div>
+            <dt>Tea</dt>
+            <dd>
+              <Link to={`/teas/${session.tea_id}`} className="inline-link">
+                #{session.tea_id}
+              </Link>
+            </dd>
+          </div>
+          <div>
+            <dt>Rating</dt>
+            <dd>{session.rating ?? "Not set"}</dd>
+          </div>
+          <div>
+            <dt>Steeps</dt>
+            <dd>{session.steeps_count ?? "Not set"}</dd>
+          </div>
+        </dl>
+
+        {session.notes ? <p className="tea-card__notes">{session.notes}</p> : null}
+      </div>
+
+      <div className="button-row">
+        <Link to={`/sessions/${session.id}`} className="button button--secondary">
+          View and edit
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/pages/TeaDetailPage.tsx
+++ b/frontend/src/pages/TeaDetailPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router";
 import { deleteTea, getTea, updateTea } from "../features/teas/api";
+import { listSessions } from "../features/sessions/api";
 import { TeaForm } from "../features/teas/TeaForm";
 import {
   type TeaFormState,
@@ -80,6 +81,16 @@ function TeaEditor({
   const [form, setForm] = useState<TeaFormState>(initialForm);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
+  const sessionsQuery = useQuery({
+    queryKey: ["sessions"],
+    queryFn: listSessions,
+  });
+
+  const relatedSessions = useMemo(
+    () => (sessionsQuery.data ?? []).filter((session) => session.tea_id === teaId),
+    [sessionsQuery.data, teaId],
+  );
+
   const updateMutation = useMutation({
     mutationFn: () => updateTea(teaId, toTeaPayload(form)),
     onSuccess: async (updatedTea) => {
@@ -127,6 +138,38 @@ function TeaEditor({
       </div>
 
       {saveMessage ? <p className="feedback feedback--success">{saveMessage}</p> : null}
+
+      <div className="panel panel--nested stack">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Sessions</p>
+            <h3>Linked sessions</h3>
+          </div>
+          <Link to="/sessions" className="button button--secondary">
+            Open sessions
+          </Link>
+        </div>
+
+        {sessionsQuery.isPending ? <p className="muted">Loading linked sessions...</p> : null}
+        {sessionsQuery.isError ? (
+          <p className="feedback feedback--error">{(sessionsQuery.error as Error).message}</p>
+        ) : null}
+        {!sessionsQuery.isPending && !sessionsQuery.isError && relatedSessions.length === 0 ? (
+          <p className="muted">No sessions are linked to this tea yet.</p>
+        ) : null}
+        {!sessionsQuery.isPending && !sessionsQuery.isError && relatedSessions.length > 0 ? (
+          <div className="linked-list">
+            {relatedSessions.map((session) => (
+              <Link key={session.id} to={`/sessions/${session.id}`} className="linked-list__item">
+                <strong>Session #{session.id}</strong>
+                <span>
+                  {new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(session.session_date))}
+                </span>
+              </Link>
+            ))}
+          </div>
+        ) : null}
+      </div>
 
       <TeaForm
         form={form}


### PR DESCRIPTION
### Motivation
- Introduce UI support for the new tea session endpoints so users can list, create, view, edit, and delete tasting sessions from the existing frontend shell. 
- Keep the same simple, panel-based design language and interaction patterns used across the app so sessions feel like a natural extension of the current UI. 

### Description
- Added session API bindings, form-state helpers, and a reusable form component under `frontend/src/features/sessions/` (`api.ts`, `formState.ts`, `SessionForm.tsx`).
- Implemented a sessions index/create page at `frontend/src/pages/SessionsPage.tsx` and a session detail/edit page at `frontend/src/pages/SessionDetailPage.tsx`, wired into routing in `frontend/src/App.tsx`.
- Surface linked sessions on the tea detail page by fetching `GET /sessions` client-side and filtering for matches; changes are in `frontend/src/pages/TeaDetailPage.tsx` and a few small CSS additions were added to `frontend/src/index.css` to match the existing visual tone.
- The UI uses the real backend contract fields (`tea_id`, `session_date`, `steeps_count`, `rating`, `notes`, `id`) and relies on the backend endpoints (`GET /sessions`, `POST /sessions`, `GET /sessions/{id}`, `PUT /sessions/{id}`, `DELETE /sessions/{id}`) without mocking or inventing additional API behavior.

### Testing
- Ran `npm --prefix frontend install --legacy-peer-deps` to fetch frontend dependencies (attempted); installation in this execution environment produced dependency warnings and was not suitable for a successful typed build. (attempted, incomplete)
- Ran `npm --prefix frontend run build` which failed in this environment due to missing type definition packages (`vite/client`, `node`) and frontend dependency peer conflicts; see build logs for details. (failed)
- Ran `npm --prefix frontend run lint` which failed because required ESLint packages (e.g. `@eslint/js`) were not available in the environment. (failed)
- Note: no backend tests were modified and no `pytest`/`ruff` runs were performed here because the issue preventing build/linting is missing/incompatible frontend dev dependencies in this environment; the UI changes are frontend-only and were validated by static code inspection and local runs attempted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baef37c45c8324b02eed9ac896d105)