### PR TITLE
feat: add tea inventory quantity tracking

### DIFF
--- a/frontend/src/features/teas/TeaForm.tsx
+++ b/frontend/src/features/teas/TeaForm.tsx
@@ -92,6 +92,36 @@ export function TeaForm({
         </label>
       </div>
 
+      <div className="field-grid">
+        <label className="field">
+          <span className="field__label">Initial quantity (g)</span>
+          <input
+            className="field__input"
+            placeholder="e.g. 100"
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="any"
+            value={form.initial_quantity_g}
+            onChange={(event) => updateField("initial_quantity_g", event.target.value)}
+          />
+        </label>
+
+        <label className="field">
+          <span className="field__label">Current quantity (g)</span>
+          <input
+            className="field__input"
+            placeholder="e.g. 45"
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="any"
+            value={form.current_quantity_g}
+            onChange={(event) => updateField("current_quantity_g", event.target.value)}
+          />
+        </label>
+      </div>
+
       <label className="field">
         <span className="field__label">Notes</span>
         <textarea

--- a/frontend/src/features/teas/api.ts
+++ b/frontend/src/features/teas/api.ts
@@ -6,6 +6,8 @@ export type Tea = {
   vendor: string | null;
   origin: string | null;
   tea_type: string | null;
+  initial_quantity_g: number | null;
+  current_quantity_g: number | null;
   harvest_year: number | null;
   notes: string | null;
 };
@@ -15,6 +17,8 @@ export type TeaInput = {
   vendor?: string | null;
   origin?: string | null;
   tea_type?: string | null;
+  initial_quantity_g?: number | null;
+  current_quantity_g?: number | null;
   harvest_year?: number | null;
   notes?: string | null;
 };
@@ -23,6 +27,7 @@ export type TeaFilters = {
   tea_type?: string;
   vendor?: string;
   name?: string;
+  in_stock?: boolean;
 };
 
 export function listTeas(filters?: TeaFilters) {
@@ -30,6 +35,7 @@ export function listTeas(filters?: TeaFilters) {
   if (filters?.tea_type) params.set("tea_type", filters.tea_type);
   if (filters?.vendor) params.set("vendor", filters.vendor);
   if (filters?.name) params.set("name", filters.name);
+  if (filters?.in_stock != null) params.set("in_stock", String(filters.in_stock));
   const qs = params.toString();
   return apiFetch<Tea[]>(qs ? `/teas?${qs}` : "/teas");
 }
@@ -55,5 +61,12 @@ export function updateTea(teaId: number, input: TeaInput) {
 export function deleteTea(teaId: number) {
   return apiFetch<void>(`/teas/${teaId}`, {
     method: "DELETE",
+  });
+}
+
+export function updateTeaQuantity(teaId: number, currentQuantityG: number) {
+  return apiFetch<Tea>(`/teas/${teaId}/quantity`, {
+    method: "PATCH",
+    body: JSON.stringify({ current_quantity_g: currentQuantityG }),
   });
 }

--- a/frontend/src/features/teas/formState.ts
+++ b/frontend/src/features/teas/formState.ts
@@ -5,6 +5,8 @@ export type TeaFormState = {
   vendor: string;
   origin: string;
   tea_type: string;
+  initial_quantity_g: string;
+  current_quantity_g: string;
   harvest_year: string;
   notes: string;
 };
@@ -14,6 +16,8 @@ export const initialTeaFormState: TeaFormState = {
   vendor: "",
   origin: "",
   tea_type: "",
+  initial_quantity_g: "",
+  current_quantity_g: "",
   harvest_year: "",
   notes: "",
 };
@@ -28,6 +32,8 @@ export function toTeaFormState(tea?: Tea): TeaFormState {
     vendor: tea.vendor ?? "",
     origin: tea.origin ?? "",
     tea_type: tea.tea_type ?? "",
+    initial_quantity_g: tea.initial_quantity_g?.toString() ?? "",
+    current_quantity_g: tea.current_quantity_g?.toString() ?? "",
     harvest_year: tea.harvest_year?.toString() ?? "",
     notes: tea.notes ?? "",
   };
@@ -39,6 +45,8 @@ export function toTeaPayload(form: TeaFormState): TeaInput {
     vendor: form.vendor.trim() || null,
     origin: form.origin.trim() || null,
     tea_type: form.tea_type.trim() || null,
+    initial_quantity_g: form.initial_quantity_g ? Number(form.initial_quantity_g) : null,
+    current_quantity_g: form.current_quantity_g ? Number(form.current_quantity_g) : null,
     harvest_year: form.harvest_year ? Number(form.harvest_year) : null,
     notes: form.notes.trim() || null,
   };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -363,6 +363,16 @@ select:disabled {
   text-underline-offset: 0.14em;
 }
 
+.pill--stock {
+  background: #e8eed9;
+  color: #46623c;
+}
+
+.pill--out-of-stock {
+  background: #f5e6e3;
+  color: #8c4438;
+}
+
 .pill--link {
   border: 1px solid #d8c8b7;
 }
@@ -470,6 +480,17 @@ select:disabled {
   color: #8a715f;
 }
 
+.quantity-update {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.quantity-update .field {
+  flex: 1;
+  max-width: 200px;
+}
+
 .checkbox-group {
   display: flex;
   flex-wrap: wrap;
@@ -511,6 +532,15 @@ select:disabled {
   .linked-list__item {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .quantity-update {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .quantity-update .field {
+    max-width: none;
   }
 
   .button-row > * {

--- a/frontend/src/pages/TeaDetailPage.tsx
+++ b/frontend/src/pages/TeaDetailPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router";
-import { deleteTea, getTea, updateTea } from "../features/teas/api";
+import { deleteTea, getTea, updateTea, updateTeaQuantity } from "../features/teas/api";
 import { listSessions } from "../features/sessions/api";
 import { TeaForm } from "../features/teas/TeaForm";
 import {
@@ -58,7 +58,7 @@ export function TeaDetailPage() {
     );
   }
 
-  return <TeaEditor key={teaQuery.data.id} teaId={teaId} initialForm={toTeaFormState(teaQuery.data)} name={teaQuery.data.name} teaType={teaQuery.data.tea_type} origin={teaQuery.data.origin} />;
+  return <TeaEditor key={teaQuery.data.id} teaId={teaId} initialForm={toTeaFormState(teaQuery.data)} name={teaQuery.data.name} teaType={teaQuery.data.tea_type} origin={teaQuery.data.origin} initialQuantityG={teaQuery.data.initial_quantity_g} currentQuantityG={teaQuery.data.current_quantity_g} />;
 }
 
 type TeaEditorProps = {
@@ -67,6 +67,8 @@ type TeaEditorProps = {
   name: string;
   teaType: string | null;
   origin: string | null;
+  initialQuantityG: number | null;
+  currentQuantityG: number | null;
 };
 
 function TeaEditor({
@@ -75,11 +77,15 @@ function TeaEditor({
   name,
   teaType,
   origin,
+  initialQuantityG,
+  currentQuantityG,
 }: TeaEditorProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [form, setForm] = useState<TeaFormState>(initialForm);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [quantityInput, setQuantityInput] = useState(currentQuantityG?.toString() ?? "");
+  const [quantityMessage, setQuantityMessage] = useState<string | null>(null);
 
   const sessionsQuery = useQuery({
     queryKey: ["sessions"],
@@ -110,6 +116,15 @@ function TeaEditor({
     },
   });
 
+  const quantityMutation = useMutation({
+    mutationFn: (qty: number) => updateTeaQuantity(teaId, qty),
+    onSuccess: async () => {
+      setQuantityMessage("Quantity updated.");
+      await queryClient.invalidateQueries({ queryKey: ["teas"] });
+      await queryClient.invalidateQueries({ queryKey: ["teas", teaId] });
+    },
+  });
+
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setSaveMessage(null);
@@ -135,7 +150,50 @@ function TeaEditor({
         <span className="pill">Tea #{teaId}</span>
         {teaType ? <span className="pill">{teaType}</span> : null}
         {origin ? <span className="pill">{origin}</span> : null}
+        {initialQuantityG != null || currentQuantityG != null ? (
+          <span className="pill pill--stock">
+            {initialQuantityG != null ? `Initial: ${initialQuantityG} g` : null}
+            {initialQuantityG != null && currentQuantityG != null ? " / " : null}
+            {currentQuantityG != null ? `Remaining: ${currentQuantityG} g` : null}
+          </span>
+        ) : null}
       </div>
+
+      {(initialQuantityG != null || currentQuantityG != null) && (
+        <div className="quantity-update">
+          <label className="field">
+            <span className="field__label">Update quantity (g)</span>
+            <input
+              className="field__input"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="any"
+              value={quantityInput}
+              onChange={(e) => {
+                setQuantityInput(e.target.value);
+                setQuantityMessage(null);
+              }}
+            />
+          </label>
+          <button
+            type="button"
+            className="button button--secondary"
+            disabled={quantityMutation.isPending || quantityInput === ""}
+            onClick={() => {
+              setQuantityMessage(null);
+              quantityMutation.mutate(Number(quantityInput));
+            }}
+          >
+            {quantityMutation.isPending ? "Saving..." : "Save"}
+          </button>
+        </div>
+      )}
+
+      {quantityMessage ? <p className="feedback feedback--success">{quantityMessage}</p> : null}
+      {quantityMutation.isError ? (
+        <p className="feedback feedback--error">{(quantityMutation.error as Error).message}</p>
+      ) : null}
 
       {saveMessage ? <p className="feedback feedback--success">{saveMessage}</p> : null}
 

--- a/frontend/src/pages/TeasPage.tsx
+++ b/frontend/src/pages/TeasPage.tsx
@@ -24,7 +24,7 @@ export function TeasPage() {
     queryFn: () => listTeas(debouncedFilters),
   });
 
-  const hasFilters = !!(filters.name || filters.vendor || filters.tea_type);
+  const hasFilters = !!(filters.name || filters.vendor || filters.tea_type || filters.in_stock);
 
   function handleFilter(field: keyof TeaFilters, value: string) {
     setFilters((prev) => ({ ...prev, [field]: value || undefined }));
@@ -86,13 +86,26 @@ export function TeasPage() {
             placeholder="All types"
           />
         </div>
-        {hasFilters && (
-          <div className="filter-bar__actions">
+        <div className="filter-bar__actions">
+          <label className="checkbox-label">
+            <input
+              type="checkbox"
+              checked={filters.in_stock === true}
+              onChange={(e) =>
+                setFilters((prev) => ({
+                  ...prev,
+                  in_stock: e.target.checked ? true : undefined,
+                }))
+              }
+            />
+            In stock only
+          </label>
+          {hasFilters && (
             <button type="button" className="button button--secondary" onClick={clearFilters}>
               Clear filters
             </button>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       {isPending ? <p className="panel muted">Loading teas...</p> : null}
@@ -124,7 +137,14 @@ export function TeasPage() {
                     <h3>{tea.name}</h3>
                     <p className="muted">{tea.vendor ?? "Unknown vendor"}</p>
                   </div>
-                  <span className="pill">#{tea.id}</span>
+                  <div className="metadata-row">
+                    {tea.current_quantity_g != null && tea.current_quantity_g > 0 ? (
+                      <span className="pill pill--stock">{tea.current_quantity_g} g</span>
+                    ) : tea.current_quantity_g != null && tea.current_quantity_g <= 0 ? (
+                      <span className="pill pill--out-of-stock">Out of stock</span>
+                    ) : null}
+                    <span className="pill">#{tea.id}</span>
+                  </div>
                 </div>
 
                 <dl className="tea-card__meta">


### PR DESCRIPTION
## Summary
- **Backend**: Add `initial_quantity_g` and `current_quantity_g` fields to the Tea model/schema, a `PATCH /teas/{id}/quantity` endpoint for quick quantity updates, and an `in_stock` query filter on the list endpoint
- **Frontend**: Wire up quantity fields in the tea form, show stock badges on tea cards, add an "In stock only" filter toggle, and provide an inline quantity update widget on the detail page
- **Tests**: Add comprehensive tests covering quantity CRUD, the in_stock filter, and edge cases

## Test plan
- [ ] Run `pytest` — all backend tests pass including new inventory tests
- [ ] Run `npx tsc --noEmit` in `frontend/` — no type errors
- [ ] Create a tea with initial/current quantities → verify they persist
- [ ] On TeasPage, verify stock badges show "X g", "Out of stock", or nothing
- [ ] Toggle "In stock only" filter → only in-stock teas shown
- [ ] On TeaDetailPage, verify quantity pill and inline update widget work
- [ ] Test mobile layout at 375px width

🤖 Generated with [Claude Code](https://claude.com/claude-code)