### PR TITLE
feat(frontend): improve tea detail UX and add keyboard nav to dropdown

### DIFF
--- a/frontend/src/features/teas/TeaForm.tsx
+++ b/frontend/src/features/teas/TeaForm.tsx
@@ -9,6 +9,7 @@ type TeaFormProps = {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   submitLabel: string;
   isSubmitting?: boolean;
+  isEditing?: boolean;
   errorMessage?: string | null;
   secondaryAction?: ReactNode;
 };
@@ -19,6 +20,7 @@ export function TeaForm({
   onSubmit,
   submitLabel,
   isSubmitting = false,
+  isEditing = false,
   errorMessage,
   secondaryAction,
 }: TeaFormProps) {
@@ -92,35 +94,37 @@ export function TeaForm({
         </label>
       </div>
 
-      <div className="field-grid">
-        <label className="field">
-          <span className="field__label">Initial quantity (g)</span>
-          <input
-            className="field__input"
-            placeholder="e.g. 100"
-            type="number"
-            inputMode="decimal"
-            min="0"
-            step="any"
-            value={form.initial_quantity_g}
-            onChange={(event) => updateField("initial_quantity_g", event.target.value)}
-          />
-        </label>
+      {!isEditing && (
+        <div className="field-grid">
+          <label className="field">
+            <span className="field__label">Initial quantity (g)</span>
+            <input
+              className="field__input"
+              placeholder="e.g. 100"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="any"
+              value={form.initial_quantity_g}
+              onChange={(event) => updateField("initial_quantity_g", event.target.value)}
+            />
+          </label>
 
-        <label className="field">
-          <span className="field__label">Current quantity (g)</span>
-          <input
-            className="field__input"
-            placeholder="e.g. 45"
-            type="number"
-            inputMode="decimal"
-            min="0"
-            step="any"
-            value={form.current_quantity_g}
-            onChange={(event) => updateField("current_quantity_g", event.target.value)}
-          />
-        </label>
-      </div>
+          <label className="field">
+            <span className="field__label">Current quantity (g)</span>
+            <input
+              className="field__input"
+              placeholder="e.g. 45"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="any"
+              value={form.current_quantity_g}
+              onChange={(event) => updateField("current_quantity_g", event.target.value)}
+            />
+          </label>
+        </div>
+      )}
 
       <label className="field">
         <span className="field__label">Notes</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -373,6 +373,19 @@ select:disabled {
   color: #8c4438;
 }
 
+.stock-bar {
+  height: 0.5rem;
+  border-radius: 999px;
+  background: #ece3d7;
+  overflow: hidden;
+}
+
+.stock-bar__fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 300ms ease;
+}
+
 .pill--link {
   border: 1px solid #d8c8b7;
 }
@@ -466,7 +479,8 @@ select:disabled {
   cursor: pointer;
 }
 
-.searchable-select__option:hover {
+.searchable-select__option:hover,
+.searchable-select__option--highlighted {
   background: #f0e4d5;
 }
 
@@ -480,15 +494,24 @@ select:disabled {
   color: #8a715f;
 }
 
-.quantity-update {
+.quantity-inline {
   display: flex;
   align-items: flex-end;
-  gap: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
 }
 
-.quantity-update .field {
-  flex: 1;
-  max-width: 200px;
+.quantity-inline__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 140px;
+}
+
+.quantity-inline .feedback {
+  align-self: center;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
 }
 
 .checkbox-group {
@@ -534,13 +557,8 @@ select:disabled {
     align-items: flex-start;
   }
 
-  .quantity-update {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .quantity-update .field {
-    max-width: none;
+  .quantity-inline__field {
+    width: 100%;
   }
 
   .button-row > * {

--- a/frontend/src/lib/SearchableSelect.tsx
+++ b/frontend/src/lib/SearchableSelect.tsx
@@ -17,8 +17,10 @@ export function SearchableSelect({
 }: SearchableSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
 
   const selectedLabel = options.find((o) => o.value === value)?.label ?? "";
 
@@ -26,43 +28,86 @@ export function SearchableSelect({
     ? options.filter((o) => o.label.toLowerCase().includes(query.toLowerCase()))
     : options;
 
+  // All selectable items: placeholder (index 0) + filtered options (index 1..N)
+  const itemCount = filtered.length + 1;
+
+  // Reset highlight when filter changes
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [query]);
+
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setOpen(false);
         setQuery("");
+        setHighlightedIndex(-1);
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const items = listRef.current.querySelectorAll("li");
+    items[highlightedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex]);
+
   function handleSelect(optionValue: string) {
     onChange(optionValue);
     setOpen(false);
     setQuery("");
+    setHighlightedIndex(-1);
   }
 
   function handleClear() {
     onChange("");
     setQuery("");
     setOpen(false);
+    setHighlightedIndex(-1);
   }
 
   function handleInputFocus() {
     setOpen(true);
     setQuery("");
+    setHighlightedIndex(-1);
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Escape") {
       setOpen(false);
       setQuery("");
+      setHighlightedIndex(-1);
       inputRef.current?.blur();
+      return;
     }
-    if (e.key === "Enter" && filtered.length === 1) {
+
+    if (!open) return;
+
+    if (e.key === "ArrowDown") {
       e.preventDefault();
-      handleSelect(filtered[0].value);
+      setHighlightedIndex((prev) => (prev + 1) % itemCount);
+      return;
+    }
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev <= 0 ? itemCount - 1 : prev - 1));
+      return;
+    }
+
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex === 0) {
+        handleSelect("");
+      } else if (highlightedIndex > 0 && highlightedIndex <= filtered.length) {
+        handleSelect(filtered[highlightedIndex - 1].value);
+      } else if (filtered.length === 1) {
+        handleSelect(filtered[0].value);
+      }
+      return;
     }
   }
 
@@ -76,6 +121,9 @@ export function SearchableSelect({
         onChange={(e) => setQuery(e.target.value)}
         onFocus={handleInputFocus}
         onKeyDown={handleKeyDown}
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
       />
       {value && !open && (
         <button
@@ -88,24 +136,26 @@ export function SearchableSelect({
         </button>
       )}
       {open && (
-        <ul className="searchable-select__dropdown">
+        <ul className="searchable-select__dropdown" ref={listRef} role="listbox">
           <li>
             <button
               type="button"
-              className={`searchable-select__option${value === "" ? " searchable-select__option--active" : ""}`}
+              className={`searchable-select__option${highlightedIndex === 0 ? " searchable-select__option--highlighted" : ""}${value === "" ? " searchable-select__option--active" : ""}`}
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => handleSelect("")}
+              onMouseEnter={() => setHighlightedIndex(0)}
             >
               {placeholder}
             </button>
           </li>
-          {filtered.map((o) => (
+          {filtered.map((o, i) => (
             <li key={o.value}>
               <button
                 type="button"
-                className={`searchable-select__option${o.value === value ? " searchable-select__option--active" : ""}`}
+                className={`searchable-select__option${highlightedIndex === i + 1 ? " searchable-select__option--highlighted" : ""}${o.value === value ? " searchable-select__option--active" : ""}`}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => handleSelect(o.value)}
+                onMouseEnter={() => setHighlightedIndex(i + 1)}
               >
                 {o.label}
               </button>

--- a/frontend/src/pages/TeaDetailPage.tsx
+++ b/frontend/src/pages/TeaDetailPage.tsx
@@ -83,7 +83,6 @@ function TeaEditor({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [form, setForm] = useState<TeaFormState>(initialForm);
-  const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [quantityInput, setQuantityInput] = useState(currentQuantityG?.toString() ?? "");
   const [quantityMessage, setQuantityMessage] = useState<string | null>(null);
 
@@ -99,11 +98,10 @@ function TeaEditor({
 
   const updateMutation = useMutation({
     mutationFn: () => updateTea(teaId, toTeaPayload(form)),
-    onSuccess: async (updatedTea) => {
-      setSaveMessage("Tea updated.");
-      setForm(toTeaFormState(updatedTea));
+    onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["teas"] });
       await queryClient.invalidateQueries({ queryKey: ["teas", teaId] });
+      navigate("/teas", { replace: true });
     },
   });
 
@@ -127,12 +125,10 @@ function TeaEditor({
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setSaveMessage(null);
     updateMutation.mutate();
   }
 
   function handleDelete() {
-    setSaveMessage(null);
     deleteMutation.mutate();
   }
 
@@ -150,19 +146,15 @@ function TeaEditor({
         <span className="pill">Tea #{teaId}</span>
         {teaType ? <span className="pill">{teaType}</span> : null}
         {origin ? <span className="pill">{origin}</span> : null}
-        {initialQuantityG != null || currentQuantityG != null ? (
-          <span className="pill pill--stock">
-            {initialQuantityG != null ? `Initial: ${initialQuantityG} g` : null}
-            {initialQuantityG != null && currentQuantityG != null ? " / " : null}
-            {currentQuantityG != null ? `Remaining: ${currentQuantityG} g` : null}
-          </span>
+        {initialQuantityG != null ? (
+          <span className="pill pill--stock">Initial: {initialQuantityG} g</span>
         ) : null}
       </div>
 
       {(initialQuantityG != null || currentQuantityG != null) && (
-        <div className="quantity-update">
-          <label className="field">
-            <span className="field__label">Update quantity (g)</span>
+        <div className="quantity-inline">
+          <label className="quantity-inline__field">
+            <span className="field__label">Remaining (g)</span>
             <input
               className="field__input"
               type="number"
@@ -185,17 +177,14 @@ function TeaEditor({
               quantityMutation.mutate(Number(quantityInput));
             }}
           >
-            {quantityMutation.isPending ? "Saving..." : "Save"}
+            {quantityMutation.isPending ? "Saving..." : "Update"}
           </button>
+          {quantityMessage ? <span className="feedback feedback--success">{quantityMessage}</span> : null}
+          {quantityMutation.isError ? (
+            <span className="feedback feedback--error">{(quantityMutation.error as Error).message}</span>
+          ) : null}
         </div>
       )}
-
-      {quantityMessage ? <p className="feedback feedback--success">{quantityMessage}</p> : null}
-      {quantityMutation.isError ? (
-        <p className="feedback feedback--error">{(quantityMutation.error as Error).message}</p>
-      ) : null}
-
-      {saveMessage ? <p className="feedback feedback--success">{saveMessage}</p> : null}
 
       <div className="panel panel--nested stack">
         <div className="section-heading">
@@ -235,6 +224,7 @@ function TeaEditor({
         onSubmit={handleSubmit}
         submitLabel="Save changes"
         isSubmitting={updateMutation.isPending}
+        isEditing
         errorMessage={updateMutation.isError ? (updateMutation.error as Error).message : null}
         secondaryAction={
           <>

--- a/frontend/src/pages/TeasPage.tsx
+++ b/frontend/src/pages/TeasPage.tsx
@@ -5,6 +5,26 @@ import { type TeaFilters, listTeas } from "../features/teas/api";
 import { useTeaTypeOptions } from "../features/tea-types/api";
 import { SearchableSelect } from "../lib/SearchableSelect";
 
+function StockBar({ current, initial }: { current: number; initial: number }) {
+  const pct = Math.max(0, Math.min(100, (current / initial) * 100));
+  const rounded = Math.round(pct);
+
+  // Gradient shifts hue: green at 100%, amber at 50%, red at 0%
+  const hue = Math.round((pct / 100) * 120); // 0 = red, 60 = amber, 120 = green
+
+  return (
+    <div className="stock-bar" role="meter" aria-valuenow={rounded} aria-valuemin={0} aria-valuemax={100} aria-label={`${rounded}% remaining`}>
+      <div
+        className="stock-bar__fill"
+        style={{
+          width: `${pct}%`,
+          background: `linear-gradient(90deg, hsl(${hue}, 45%, 42%), hsl(${hue}, 50%, 55%))`,
+        }}
+      />
+    </div>
+  );
+}
+
 function useDebounced<T>(value: T, delay = 300): T {
   const [debounced, setDebounced] = useState(value);
   useEffect(() => {
@@ -163,6 +183,10 @@ export function TeasPage() {
                 </dl>
 
                 {tea.notes ? <p className="tea-card__notes">{tea.notes}</p> : null}
+
+                {tea.initial_quantity_g != null && tea.initial_quantity_g > 0 && tea.current_quantity_g != null ? (
+                  <StockBar current={tea.current_quantity_g} initial={tea.initial_quantity_g} />
+                ) : null}
               </div>
 
               <div className="button-row">


### PR DESCRIPTION
- Save changes now navigates back to teas list
- Move quantity update to compact inline widget under metadata pills
- Hide initial/current quantity fields from edit form (set-once at creation)
- Add stock bar gradient widget to tea cards showing remaining %
- Add arrow key navigation and Enter to confirm in SearchableSelect